### PR TITLE
ci: install g++ compiler for Node.js v4 later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: node_js
 node_js:
-- '6'
-- '5'
-- '4'
+  - '6'
+  - '5'
+  - '4'
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 after_success: npm run coverage


### PR DESCRIPTION
See https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements